### PR TITLE
Update require PHP version to 5.4 at composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"source" : "http://sourceforge.jp/projects/pukiwiki-adv/releases/"
 	},
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.4.0",
 		"aferrandini/phpqrcode": "1.*",
 		"facebook/php-sdk": "3.*",
 		"zendframework/zendframework": "2.*",


### PR DESCRIPTION
http://pukiwiki.logue.be/
での動作環境に明記されてる通りPHPヴァージョンをcomposer側にも適用します。

ちなみにphpcompatinfo `http://php5.laurent-laville.org/compatinfo/`
で確認した結果、現在5.4の機能を使ってる箇所としては、trait以外で`SORT_NATURAL`定数・`hex2bin()`関数の呼び出しがあり、
ミニヴァージョンも`0`で、5.4.0で間違いなさそうです。
