### PR TITLE
Router.php: HTTP_HOST could have :port

### DIFF
--- a/wiki-common/lib/PukiWiki/Router.php
+++ b/wiki-common/lib/PukiWiki/Router.php
@@ -101,7 +101,9 @@ class Router{
 		$msg	 = 'get_script_absuri() failed: Please set [$script or $script_abs] at INI_FILE manually';
 
 		$uri  = ( ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
-		$uri .= ($_SERVER['SERVER_PORT'] == 80 || $_SERVER['SERVER_PORT'] == 443) ? '' : ':' . $_SERVER['SERVER_PORT'];  // port
+                if(strpos($uri,':')===FALSE) {
+                        $uri .= ($_SERVER['SERVER_PORT'] == 80 || $_SERVER['SERVER_PORT'] == 443) ? '' : ':' . $_SERVER['SERVER_PORT'];  // port
+                }
 
 		// SCRIPT_NAME が'/'で始まっていない場合(cgiなど) REQUEST_URIを使ってみる
 		$path	= SCRIPT_NAME;


### PR DESCRIPTION
HTTP_HOSTは:portを含む可能性があるため、:が含まれる場合はポート番号を付加する処理は行わないようにする必要があります。
