### PR TITLE
名前空間の間違いを修正。

### DIFF
--- a/wiki-common/lib/PukiWiki/Ping.php
+++ b/wiki-common/lib/PukiWiki/Ping.php
@@ -96,7 +96,7 @@ class Ping{
 	 * Pubsubhubbub送信
 	 */
 	public function sendPubsubhubbub(){
-		$publisher = new Zend\Feed\PubSubHubbub\Publisher;
+		$publisher = new Publisher;
 		$publisher->addHubUrls($this->pubsubhubbub_server);
 		$publisher->addUpdatedTopicUrls(array(
 			$this->wiki->uri()


### PR DESCRIPTION
名前空間が相対パスになっていたのでクラスが読み込めていませんでした。
冒頭でuseしているので省略しました。
他の箇所でも同様のものがあるようです。ご確認お願いします。