### PR TITLE
Ping周りの不具合を仮修正。

### DIFF
--- a/wiki-common/lib/PukiWiki/Ping.php
+++ b/wiki-common/lib/PukiWiki/Ping.php
@@ -129,19 +129,21 @@ class Ping{
 	 */
 	public function sendWeblogUpdatesPing(){
 		global $site_name;
+		
+		$err = array();
 
 		$request = new XmlRpcRequest();
 		$request->setMethod('weblogUpdates.ping');
 		$request->setParams(array($site_name, Router::get_script_absuri(), $this->wiki->uri()));
 
 		// 送信
-		foreach ($this->ping_server as $uri){
+		foreach ($this->weblog_updates_ping_server as $uri){
 			try {
 				// Pingサーバーに接続
 				$client = new XmlRpcClient($uri);
 				// Pingの送信
 				$client->doRequest($request);
-			} catch (Zend\XmlRpc\Client\Exception\FaultException $e) {
+			} catch (\Zend\XmlRpc\Client\Exception\FaultException $e) {
 				$err[] = $e;
 			}
 		}


### PR DESCRIPTION
以下とりいそぎざっくりですが、修正してみました。
- 返り値の$err変数がUndefinedになっていたので初期化しました。
- $this->ping_serverもUndefinedだったので$this->weblog_updates_ping_serverに書き換えました。
- FaultExceptionのパスが相対だったので、絶対にしました。

しかし、$this->weblog_updates_ping_serverはセッターによると配列ではない場合も想定していますが、foreachに突っ込んでいる以上、配列でないと問題が起きる可能性があります。
