### PR TITLE
HHVM上でページが出力されない不具合を修正

### DIFF
--- a/wiki-common/lib/init.php
+++ b/wiki-common/lib/init.php
@@ -365,6 +365,16 @@ if ( isset($auth_api['facebook']) ){
 	}
 }
 */
+
+///////////////////////////////////////
+// HHVM hack
+
+if (!function_exists('ob_gzhandler')) {
+	function ob_gzhandler ($buffer, $mode) {
+		return FALSE;
+	}
+}
+
 /////////////////////////////////////////////////
 // Execute Plugin.
 


### PR DESCRIPTION
HHVMはob_gzhandlerをサポートしていません．

DEBUGが定義されている時にはページが出力されますが，されていない時には何も出力されません．
ob_gzhandlerが定義されていないときにダミーの関数を定義することでこの問題を回避することができます．

処理系の問題（仕様？）を持ち込むべきか迷いましたが，一応PRを送ります．

>NOT SUPPORTED IN HHVM
http://docs.hhvm.com/manual/en/function.ob-gzhandler.php