### PR TITLE
変数のスコープを修正

### DIFF
--- a/wiki-common/lib/PukiWiki/Attach.php
+++ b/wiki-common/lib/PukiWiki/Attach.php
@@ -205,7 +205,7 @@ class Attach{
 	 * 削除する
 	 */
 	public function delete($pass){
-		global $notify;
+		global $notify, $notify_subject;
 		if ($this->status['freeze']){
 			// ここではチェックしない
 			return false;

--- a/wiki-common/lib/PukiWiki/File/DiffFile.php
+++ b/wiki-common/lib/PukiWiki/File/DiffFile.php
@@ -44,7 +44,7 @@ class DiffFile extends AbstractFile{
 	 * @param string $str
 	 */
 	public function set($diffdata = '', $keeptimestamp = false){
-		global $notify, $notify_diff_only;
+		global $notify, $notify_diff_only, $notify_subject;
 		// 差分を作成
 		//$diff = new Diff(WikiFactory::Wiki($this->page)->source(true), explode("\n",$postdata));
 		//$str = $diff->getDiff();


### PR DESCRIPTION
グローバル変数の$notify_subjectを参照すべきところがグローバルになっておらず，
ページの編集や凍結解除時に``ランタイムエラー Mailer::notify(): Failed``が発生する．