### PR TITLE
ページがリネームできない不具合の修正

### DIFF
--- a/wiki-common/lib/PukiWiki/Relational.php
+++ b/wiki-common/lib/PukiWiki/Relational.php
@@ -133,7 +133,7 @@ class Relational{
 		$rel_exist = ($rel_old === array());
 
 		$rel_auto = $rel_new = array();
-		foreach (self::getObjects($page, TRUE) as $_obj) {
+		foreach (self::getObjects($page) as $_obj) {
 			if (! isset($_obj->type) || $_obj->type !== 'pagename' || $_obj->name === $page || empty($_obj->name) )
 				continue;
 

--- a/wiki-common/lib/PukiWiki/Relational.php
+++ b/wiki-common/lib/PukiWiki/Relational.php
@@ -133,19 +133,22 @@ class Relational{
 		$rel_exist = ($rel_old === array());
 
 		$rel_auto = $rel_new = array();
-		foreach (self::getObjects($page) as $_obj) {
-			if (! isset($_obj->type) || $_obj->type !== 'pagename' || $_obj->name === $page || empty($_obj->name) )
-				continue;
+		$pages = self::getObjects($page);
+		if (!empty($pages)) {
+			foreach ($pages as $_obj) {
+				if (! isset($_obj->type) || $_obj->type !== 'pagename' || $_obj->name === $page || empty($_obj->name) )
+					continue;
 
-			if ($_obj instanceof AutoLink) { // Not cool though
-				$rel_auto[] = $_obj->name;
-			} else if ($_obj instanceof AutoAlias) {
-				$_alias = AutoAlias::getAutoAliasDict($_obj->name);
-				if (Factory::Wiki($_alias)->isValied()) {
-					$rel_auto[] = $_alias;
+				if ($_obj instanceof AutoLink) { // Not cool though
+					$rel_auto[] = $_obj->name;
+				} else if ($_obj instanceof AutoAlias) {
+					$_alias = AutoAlias::getAutoAliasDict($_obj->name);
+					if (Factory::Wiki($_alias)->isValied()) {
+						$rel_auto[] = $_alias;
+					}
+				} else {
+					$rel_new[]  = $_obj->name;
 				}
-			} else {
-				$rel_new[]  = $_obj->name;
 			}
 		}
 
@@ -308,20 +311,21 @@ class Relational{
 
 	/**
 	 * ページのソースからリンクオブジェクトを取得
-	 * @param type $page
-	 * @return type
+	 * @param string $page
+	 * @return object|null
 	 */
 	private function getObjects($page=''){
 		static $result;
 		if (empty($page)) {
 			unset($result);
-			return;
+			return null;
 		}
 		if (! isset($result[$page]) ){
 			$source = Factory::Wiki($page)->get(false);
 			$result[$page] = ($source !== false) ? $this->links_obj->getObjects(join('', preg_grep('/^(?!\/\/|\s)./', $source)), $page) : null;
+			return $result[$page];
 		}
-		return $result[$page];
+		return null;
 	}
 
 	// もっとマシなSQL文って無い？

--- a/wiki-common/lib/PukiWiki/Renderer/Inline/Inline.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Inline/Inline.php
@@ -33,7 +33,7 @@ abstract class Inline
 
 	protected $type;
 	protected $page;
-	protected $name;
+	public $name;
 	protected $body;
 	protected $alias;
 

--- a/wiki-common/lib/legacy.php
+++ b/wiki-common/lib/legacy.php
@@ -553,9 +553,14 @@ function make_heading(& $str, $strip = TRUE)
 	return Rules::getHeading($str, $strip);
 }
 
+/**
+ * @return bool
+ */
 function pkwk_headers_sent()
 {
-	return Header::checkSent();
+	//未定義
+//	return Header::checkSent();
+	return headers_sent();
 }
 
 function pkwk_common_headers($modified = 0, $expire = 604800){

--- a/wiki-common/plugin/rename.inc.php
+++ b/wiki-common/plugin/rename.inc.php
@@ -15,6 +15,7 @@ use PukiWiki\Wiki;
 use PukiWiki\Factory;
 use PukiWiki\Utility;
 use PukiWiki\Router;
+use PukiWiki\Relational;
 
 define('PLUGIN_RENAME_LOGPAGE', ':RenameLog');
 
@@ -72,7 +73,7 @@ function plugin_rename_action()
 			if (! is_pagename($page)){
 				return plugin_rename_phase1('notvalid');
 			}else if (preg_match(Wiki::INVALIED_PAGENAME_PATTERN, $page)){
-				die_message($_strings['illegal_chars']);
+				die_message($_string['illegal_chars']);
 			}
 		}
 
@@ -86,7 +87,7 @@ function plugin_rename_action()
 		
 		// Check Illigal Chars
 		if (preg_match(Wiki::INVALIED_PAGENAME_PATTERN, $page)){
-			die_message($_strings['illegal_chars']);
+			die_message($_string['illegal_chars']);
 		}
 
 		if (empty($refer)) {
@@ -97,7 +98,7 @@ function plugin_rename_action()
 		} else if (is_cantedit($refer)) {
 			return plugin_rename_phase1('norename', $refer);
 
-		 } else if (!empty($page) || $page === $refer) {
+		 } else if (!empty($page) && $page === $refer) {
 			return plugin_rename_phase2();
 
 		} else if (! is_pagename($page)) {

--- a/wiki-common/plugin/rename.inc.php
+++ b/wiki-common/plugin/rename.inc.php
@@ -472,15 +472,17 @@ function plugin_rename_get_files($pages)
 	// At this time, collision detection is not implemented
 
 	$wiki->set($postdata);
-
-	cache_timestamp_touch();
+//未定義
+//	cache_timestamp_touch();
 
 	$page = plugin_rename_getvar('page');
 	if ($page == '') $page = PLUGIN_RENAME_LOGPAGE;
 
 	// Redirection
-	pkwk_headers_sent();
-	header('Location: ' . get_page_location_uri($page));
+
+	if(!pkwk_headers_sent()) {
+		header('Location: ' . get_page_location_uri($page));
+	}
 	exit;
 }
 

--- a/wiki-common/plugin/rename.inc.php
+++ b/wiki-common/plugin/rename.inc.php
@@ -383,13 +383,12 @@ EOD;
 
 function plugin_rename_get_files($pages)
 {
-	global $log,$trackback,$referer;
+	global $log;
 
 	$files = array();
 	$dirs  = array(BACKUP_DIR, DIFF_DIR, DATA_DIR);
 	if (exist_plugin_convert('attach'))  $dirs[] = UPLOAD_DIR;
 	if (exist_plugin_convert('counter')) $dirs[] = COUNTER_DIR;
-	if ($trackback > 0 || $referer > 0) $dirs[] = TRACKBACK_DIR;
 	foreach(array('update','download','browse') as $log_subdir) {
 		if ($log[$log_subdir]['use']) $dirs[] = LOG_DIR.$log_subdir.'/';
 	}


### PR DESCRIPTION
作成済みページの名前が変更できないので修正しました。動くようにはなりましたが、次の問題は他のプラグインでも見受けられ、正しく動いていない気がします。

1. trackbackに対する処置が不明
 * 本家でも動作していないらしいので単純に削除してしまいましたが、他のプラグインにも同様の呼び出しが残ってます。廃止でいい?
2. pkwk_headers_sent()が未定義
 * 単純にheaders_sent()に置換してしまいましたが、呼び出し元がif判定していないので、元々、別の機能が意図されていたような気がします。
