### PR TITLE
ページ名にマッチした場合は通常検索をスキップするように変更

### DIFF
--- a/wiki-common/lib/PukiWiki/Search.php
+++ b/wiki-common/lib/PukiWiki/Search.php
@@ -156,13 +156,16 @@ class Search{
 				}
 			}
 
-			// 通常検索
-			$source = $wiki->get(true);
-			foreach ($keys as $key) {
-				$b_match = preg_match($key, $source);
-				if ($b_type xor $b_match) break; // OR
+			// 通常検索 (ページ名にマッチしない場合)
+			if (!$b_match) {
+				$source = $wiki->get(true);
+				foreach ($keys as $key) {
+					$b_match = preg_match($key, $source);
+					if ($b_type xor $b_match) break; // OR
+				}
+				unset($source, $key);
 			}
-			unset($source, $key);
+
 			// マッチしない場合スキップ
 			if (!$b_match) continue;
 


### PR DESCRIPTION
#37 を踏まえて．

ページ名から検索 で `$b_match` が TRUEになっても 通常検索 で上書きされてしまい，
ページの内容にマッチしない限り引っかからないようになっていました．

ページ名にマッチした場合は通常検索をスキップしても良いのでは？