### PR TITLE
書き換えを伴う foreach でリファレンスを使用するように変更

### DIFF
--- a/wiki-common/lib/PukiWiki/File/FileUtility.php
+++ b/wiki-common/lib/PukiWiki/File/FileUtility.php
@@ -205,11 +205,11 @@ class FileUtility{
 		// ページの索引でソート
 		ksort($ret, SORT_NATURAL);
 
-		foreach ($ret as $initial=>$pages){
+		foreach ($ret as $initial => &$pages){
 			// ページ名の「読み」でソート
-			asort($ret[$initial], SORT_NATURAL);
+			asort($pages, SORT_NATURAL);
 			// 「読み」でソートしたやつを$headingに保存
-			$heading[$func][$initial] = array_keys($ret[$initial]);
+			$heading[$func][$initial] = array_keys($pages);
 		}
 		unset($ret);
 

--- a/wiki-common/lib/PukiWiki/Listing.php
+++ b/wiki-common/lib/PukiWiki/Listing.php
@@ -92,11 +92,11 @@ class Listing{
 		// ページの索引でソート
 		ksort($ret, SORT_NATURAL);
 
-		foreach ($ret as $initial=>$pages){
+		foreach ($ret as $initial => &$pages){
 			// ページ名の「読み」でソート
-			asort($ret[$initial], SORT_NATURAL);
+			asort($pages, SORT_NATURAL);
 			// 「読み」でソートしたやつを$headingに保存
-			$heading[$type][$initial] = array_keys($ret[$initial]);
+			$heading[$type][$initial] = array_keys($pages);
 		}
 		unset($ret);
 

--- a/wiki-common/lib/PukiWiki/Mailer.php
+++ b/wiki-common/lib/PukiWiki/Mailer.php
@@ -49,8 +49,8 @@ class Mailer{
 
 		if (! empty($summary)) {
 			$_separator = empty($message) ? '' : self::SUMMRY_SEPARATOR . "\n";
-			foreach($summary as $key => $value) {
-				$summary[$key] = $key . ': ' . $value . "\n";
+			foreach($summary as $key => &$value) {
+				$value = $key . ': ' . $value . "\n";
 			}
 			// Top or Bottom
 			if ($summary_position) {

--- a/wiki-common/lib/PukiWiki/Renderer/Element/RootElement.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/RootElement.php
@@ -263,8 +263,8 @@ class RootElement extends Element
 	private function comment($matches)
 	{
 		$comments = explode("\n", $matches[0]);
-		foreach ($comments as $key=>$comment) {
-			$comments[$key] = array_shift($this->comments);
+		foreach ($comments as &$comment) {
+			$comment = array_shift($this->comments);
 		}
 		$comment = join("\n", $comments);
 		return '<span class="fa fa-comment" title="' . Utility::htmlsc($comment) . '"></span>';

--- a/wiki-common/lib/PukiWiki/Search.php
+++ b/wiki-common/lib/PukiWiki/Search.php
@@ -126,8 +126,8 @@ class Search{
 
 		// 検索ワードをパース
 		$keys = self::get_search_words(preg_split('/\s+/', $word, -1, PREG_SPLIT_NO_EMPTY));
-		foreach ($keys as $key=>$value)
-			$keys[$key] = '/' . $value . '/S';
+		foreach ($keys as &$value)
+			$value = '/' . $value . '/S';
 
 		// AND:TRUE OR:FALSE
 		$b_type = ($type == 'and');

--- a/wiki-common/lib/PukiWiki/Spam/Spam.php
+++ b/wiki-common/lib/PukiWiki/Spam/Spam.php
@@ -590,11 +590,11 @@ class Spam{
 		// Shrink per list
 		// From: 'A-1' => array('ie.to')
 		// To:   'A-1' => 'ie.to'
-		foreach($blocked as $list => $lvalue) {
+		foreach($blocked as &$lvalue) {
 			if (is_array($lvalue) &&
 			   count($lvalue) == 1 &&
 			   is_numeric(key($lvalue))) {
-			    $blocked[$list] = current($lvalue);
+				$lvalue = current($lvalue);
 			}
 		}
 

--- a/wiki-common/lib/PukiWiki/Spam/SpamUtility.php
+++ b/wiki-common/lib/PukiWiki/Spam/SpamUtility.php
@@ -298,12 +298,12 @@ class SpamUtility{
 		if (! is_array($array)) return $array;
 
 		$tmp = array();
-		foreach($array as $key => $value){
+		foreach($array as &$value){
 			if (is_array($value)) {
-				$array[$key] = self::array_unique_recursive($value);
+				$value = self::array_unique_recursive($value);
 			} else {
 				if (isset($tmp[$value])) {
-					unset($array[$key]);
+					unset($value);
 				} else {
 					$tmp[$value] = TRUE;
 				}

--- a/wiki-common/plugin/htdigest.inc.php
+++ b/wiki-common/plugin/htdigest.inc.php
@@ -325,7 +325,7 @@ function htdigest_save($username,$p_realm,$hash,$role)
 	}
 
 	$sw = FALSE;
-	foreach($lines as $no=>$line) {
+	foreach($lines as &$line) {
 		$field = explode(':', trim($line));
 		if ($field[0] == $username && $field[1] == $p_realm) {
 			if ($field[2] == $decrypted_hash) {
@@ -333,7 +333,7 @@ function htdigest_save($username,$p_realm,$hash,$role)
 			}
 
 			$sw = TRUE;
-			$lines[$no] = $field[0].':'.$field[1].':'.$decrypted_hash."\n";
+			$line = $field[0].':'.$field[1].':'.$decrypted_hash."\n";
 			break;
 		}
 	}

--- a/wiki-common/plugin/htmlinsert.inc.php
+++ b/wiki-common/plugin/htmlinsert.inc.php
@@ -73,12 +73,12 @@ class PluginHtmlinsert
 		$options = $default_options;
 		unset($vars['cmd']);  // pukiwiki reserved key
 		unset($vars['page']); // 
-		foreach ($vars as $key => $val) {
+		foreach ($vars as $key => &$val) {
 			if (isset($options[$key])) {
 				$options[$key] = $val;
-				unset($vars[$key]);
+				unset($val);
 			} else {
-				$vars[$key] = htmlsc($val);
+				$val = htmlsc($val);
 			}
 		}
 		return array($page, $vars, $options);
@@ -227,26 +227,26 @@ class PluginHtmlinsert
 				return;
 			}
 		}
-		foreach ($values as $idx => $value) {
+		foreach ($values as $idx => &$value) {
 			switch ($encs[$idx]) {
 			case 'enc':
-				$values[$idx] = rawurlencode($value);
+				$value = rawurlencode($value);
 				break;
 			case 'utf8':
 				$value = mb_convert_encoding($value, 'UTF-8', SOURCE_ENCODING);
-				$values[$idx] = rawurlencode($value);
+				$value = rawurlencode($value);
 				break;
 			case 'euc':
 				$value = mb_convert_encoding($value, 'EUC', SOURCE_ENCODING);
-				$values[$idx] = rawurlencode($value);
+				$value = rawurlencode($value);
 				break;
 			case 'sjis':
 				$value = mb_convert_encoding($value, 'SJIS', SOURCE_ENCODING);
-				$values[$idx] = rawurlencode($value);
+				$value = rawurlencode($value);
 				break;
 			case 'jis':
 				$value = mb_convert_encoding($value, 'JIS', SOURCE_ENCODING);
-				$values[$idx] = rawurlencode($value);
+				$value = rawurlencode($value);
 				break;
 			case '':
 			case 'raw':

--- a/wiki-common/plugin/vote.inc.php
+++ b/wiki-common/plugin/vote.inc.php
@@ -207,11 +207,11 @@ class PluginVotex
 					list($votes, $options) = $this->parse_args_inline($args, $this->default_options);
 					if ($options['readonly']) return array(false, false, false, false);
 
-					foreach ($votes as $i => $vote) {
+					foreach ($votes as $i => &$vote) {
 						list($choice, $count) = $vote;
 						if ($i == $choice_id) {
 							++$count;
-							$votes[$i] = array($choice, $count);
+							$vote = array($choice, $count);
 						}
 					}
 					$new_args = $this->restore_args_inline($votes, $options, $this->default_options);


### PR DESCRIPTION
## 理由
 - 添字よりもリファレンスを使用する方が早い（**若干**）

![](http://i.imgur.com/vvdMkkO.png)
※長い配列をforeachでまわして，添字もしくはリファレンスを使用して読み書きを続けた時の結果（PHP 7.0.6）