### PR TITLE
微修正

### DIFF
--- a/wiki-common/lib/PukiWiki/Lang/Holiday/PublicHoliday.php
+++ b/wiki-common/lib/PukiWiki/Lang/Holiday/PublicHoliday.php
@@ -260,7 +260,7 @@ abstract class PublicHoliday
 			$y--;
 			$m += 12;
 		}
-		$d = $y + floor($y/4) - floor($y/100) + floor($y/400) + floor(2.6*$m+1.6) + $d;
+		$d += $y + floor($y/4) - floor($y/100) + floor($y/400) + floor(2.6*$m+1.6);
 		return ($d%7);
 	}
 

--- a/wiki-common/lib/PukiWiki/Renderer/Inline/Inline.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Inline/Inline.php
@@ -31,7 +31,7 @@ abstract class Inline
 	protected $start;   // Origin number of parentheses (0 origin)
 	protected $text;    // Matched string
 
-	protected $type;
+	public $type;
 	protected $page;
 	public $name;
 	protected $body;

--- a/wiki-common/plugin/tracker.inc.php
+++ b/wiki-common/plugin/tracker.inc.php
@@ -1385,7 +1385,7 @@ class Tracker_list
 		}
 
 		// This column will be the first position , if you click
-		$orders = array($fieldname => $order) + $orders;
+		$orders += array($fieldname => $order);
 
 		$_orders = array();
 		foreach ($orders as $_fieldname => $_order) {


### PR DESCRIPTION
## 複合演算子に置き換え
前のコミットに入れ忘れた分を追加しました．

## プリペアドステートメントを使用するように変更
 - `quoteIdentifier()` を結合していたのをプリペアドステートメントへ変更
 - `$s->execute()` を `query($sql, Adapter::QUERY_MODE_EXECUTE)` へ変更

## リンクのデータベースが更新されない問題を修正
`$_obj->type` にアクセスすることが出来ず，`isset($_obj->type)` が常に `FALSE` になってしまう．
e6e2aabf60a5b9dbdb4ff2b7e76598d234833ad5 までは動作していた模様．

### 問題の箇所
https://github.com/logue/pukiwiki_adv/blob/master/wiki-common/lib/PukiWiki/Relational.php#L139
https://github.com/logue/pukiwiki_adv/blob/master/wiki-common/lib/PukiWiki/Relational.php#L213