### PR TITLE
CSV形式の表組みを中央揃えに変更

### DIFF
--- a/wiki-common/lib/PukiWiki/Renderer/Element/YTable.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/YTable.php
@@ -25,8 +25,8 @@ use PukiWiki\Renderer\InlineFactory;
 class YTable extends Element
 {
 	protected $col;	// Number of columns
-	
-	public $align;
+
+	public $align = 'center';
 
 	// TODO: Seems unable to show literal '==' without tricks.
 	//       But it will be imcompatible.
@@ -94,7 +94,7 @@ class YTable extends Element
 		foreach ($this->elements as $str) {
 			$rows .= "\n" . '<tr>' . $str . '</tr>' . "\n";
 		}
-		$rows = $this->wrap($rows, 'table', ' class="table ' . $this->align . '" data-pagenate="false"');
+		$rows = $this->wrap($rows, 'table', ' class="table table-bordered table_' . $this->align . '" data-pagenate="false"');
 		return $this->wrap($rows, 'div', ' class="table_wrapper"');
 	}
 }


### PR DESCRIPTION
表組み と CSV形式の表組み の揃え位置が異なる．
本家にあわせるのであれば CSV形式の表組み も中央揃えに変更した方が…と思ったのですが，いかがでしょうか．

## 参考

### PukiWiki Advance HEAD
表組みは中央，CSV形式の表組みは**左**．
![](http://i.imgur.com/xY9wdhC.png)

### PukiWiki 1.5
両者ともに中央
![](http://i.imgur.com/aqDFMAi.png)