### PR TITLE
スペースを含むセルが空になる問題を修正

### DIFF
--- a/wiki-common/lib/PukiWiki/Renderer/Element/YTable.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/YTable.php
@@ -66,7 +66,7 @@ class YTable extends Element
 			$colspan = 1;
 			while (isset($_value[$i + $colspan]) && $_value[$i + $colspan] === FALSE) ++$colspan;
 			$colspan = ($colspan > 1) ? ' colspan="' . $colspan . '"' : '';
-			$text = preg_match("/\s+/", $_value[$i]) ? '' : InlineFactory::factory($_value[$i]);
+			$text = preg_match("/\S+/", $_value[$i]) ? InlineFactory::factory($_value[$i]) : '';
 			$class = ((empty($text) || !preg_match("/\S+/", $text))) ? 'blank-cell' : '';
 			$align = $_align[$i] ? ' style="text-align:' . $_align[$i] . '"' : '';
 			$str[] = '<td class="'.$class.'"' . $align . $colspan . '>' . $text . '</td>';


### PR DESCRIPTION
CSV形式の表組み でスペースを含むセルが空になる問題．

## 例
```
|nospace|s p a c e|nospace|
,nospace,s p a c e,nospace
```

### 表組み

```html
<tbody>
<tr>
<td>nospace</td>
<td>s p a c e</td>
<td>nospace</td>
</tr>
</tbody>
```

### CSV形式の表組み
```s p a c e```が行方不明に…

```html
<tr>
<td class="">nospace</td>
<td class="blank-cell"></td>
<td class="">nospace</td>
</tr>
```