### PR TITLE
参照渡しを要求するメソッドに値を直接渡さないように変更

### DIFF
--- a/wiki-common/lib/PukiWiki/Renderer/Element/ListContainer.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/ListContainer.php
@@ -35,7 +35,9 @@ class ListContainer extends Element
 		$this->level = min(3, strspn($text, $head));
 		$text = ltrim(substr($text, $this->level));
 
-		parent::insert(new ListElement($this->level, $tag2));
+		$element = new ListElement($this->level, $tag2);
+
+		parent::insert($element);
 		if ( !empty($text) )
 			$this->last = $this->last->insert(ElementFactory::factory('InlineElement', null, $text));
 	}

--- a/wiki-common/lib/PukiWiki/Renderer/Element/RootElement.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/RootElement.php
@@ -124,7 +124,8 @@ class RootElement extends Element
 
 			// Heading
 			if ($head === '*') {
-				$this->insert(new Heading($this, $line));
+				$heading = new Heading($this, $line);
+				$this->insert($heading);
 				continue;
 			}
 
@@ -237,7 +238,8 @@ class RootElement extends Element
 		//var_dump($text, $id, $level);
 
 		// Add 'page contents' link to its heading
-		$this->contents_last = $this->contents_last->add(new ContentsList($_text, $level, $id));
+		$contents = new ContentsList($_text, $level, $id);
+		$this->contents_last = $this->contents_last->add($contents);
 
 		// Add heding
 		return array($_text . $anchor, $this->count > 1 ? "\n" . $top : '', $autoid);


### PR DESCRIPTION
```
PHP Notice:  Only variables should be passed by reference in ~
```