### PR TITLE
#50 導入後にいくつかの要素が正しくレンダリングされない問題を修正

### DIFF
--- a/wiki-common/lib/PukiWiki/Renderer/Element/Element.php
+++ b/wiki-common/lib/PukiWiki/Renderer/Element/Element.php
@@ -46,7 +46,7 @@ class Element
 	{
 		if (gettype($obj) === 'object'){
 			$obj->setParent($this);
-			$this->elements[] = & $obj;
+			$this->elements[] = $obj;
 
 			$this->last = & $obj->last;
 		}


### PR DESCRIPTION
## 問題の箇所

#50 の修正により、値渡し から 参照渡し に変わることで、同じ要素が何度も出力される問題が発生

```
$this->elements[] = & $obj;
```

## example

```php
class Person {
    private $children;
    private $fullname;

    function __construct($fullname = "John Doe") {
        $this->fullname = $fullname;
        $this->children = array();
    }

    public function add(& $child) {
        $this->children[] = & $child;
    }

    public function dump() {
        var_dump($this->children);
    }
}

/*
こちらは 値渡し
$bigDaddy->add(new Person("白 子"));

array(2) {
  [0]=>
  object(Person)#2 (2) {
    ["children":"Person":private]=>
    array(0) {
    }
    ["fullname":"Person":private]=>
    string(7) "白 子"
  }
  [1]=>
  object(Person)#3 (2) {
    ["children":"Person":private]=>
    array(0) {
    }
    ["fullname":"Person":private]=>
    string(7) "海 胆"
  }
}

*/

$bigDaddy = new Person("海鼠 太郎");
$bigDaddy->add(new Person("白 子"));
$bigDaddy->add(new Person("海 胆"));
$bigDaddy->dump();

/*
WTF!?!?

こちらは 参照渡し
$tmp = "hogehoge";
$bigDaddy->add($tmp);

array(2) {
  [0]=>
  &object(Person)#3 (2) {
    ["children":"Person":private]=>
    array(0) {
    }
    ["fullname":"Person":private]=>
    string(7) "海 胆"
  }
  [1]=>
  &object(Person)#3 (2) {
    ["children":"Person":private]=>
    array(0) {
    }
    ["fullname":"Person":private]=>
    string(7) "海 胆"
  }
}
*/

$bigDaddy = new Person("海鼠 太郎");

foreach (array("白 子", "海 胆") as $name) {
    /* 何かする */
    $tmp = new Person($name);
    $bigDaddy->add($tmp);
}

$bigDaddy->dump();
```